### PR TITLE
fixed bugs with timeKeeper and notifications

### DIFF
--- a/scripts/AudioManager.js
+++ b/scripts/AudioManager.js
@@ -14,6 +14,7 @@ function AudioManager(addEventListener, isTownTune) {
 	var killLoopTimeout;
 	var killFadeInterval;
 	var townTuneManager = new TownTuneManager();
+	var timeKeeper = new TimeKeeper();
 
 	// isHourChange is true if it's an actual hour change,
 	// false if we're activating music in the middle of an hour

--- a/scripts/NotificationManager.js
+++ b/scripts/NotificationManager.js
@@ -3,6 +3,7 @@
 'use strict';
 
 function NotificationManager(addEventListener, isEnabled) {
+	let weather;
 
 	function doNotification (message) {
 		chrome.notifications.create('animal-crossing-music', {
@@ -15,18 +16,19 @@ function NotificationManager(addEventListener, isEnabled) {
 	}
 
 	addEventListener("weatherChange", function(weather) {
+
 		if (isEnabled()) {
-			let weather = weather.toLowerCase();
-			doNotification(weather + (weather !== 'clear' ? 'ing' : ''));
+			let lowerWeather = weather.toLowerCase();
+			doNotification(lowerWeather + (lowerWeather !== 'clear' ? 'ing' : ''));
 		}
 	});
 	
 	addEventListener("hourMusic", function(hour) {
-		isEnabled && doNotification(`It is now ${formatHour(hour)}m`);
+		isEnabled() && doNotification(`It is now ${formatHour(hour)}m`);
 	});
 
 	addEventListener("kkStart", function() {
-		isEnabled && doNotification('K.K. Slider has started to play!');
+		isEnabled() && doNotification('K.K. Slider has started to play!');
 	});
 
 }

--- a/scripts/TimeKeeper.js
+++ b/scripts/TimeKeeper.js
@@ -10,7 +10,12 @@ function TimeKeeper() {
 	
 	// DECLARING TIME VARIABLES
 	var date, currHour, currDay, currMonth, currDate;
-	
+	// running updateTimeVariables created issues, because JavaScript, so initially updating these manually.
+	date = new Date();
+	currHour = date.getHours();
+	currDay = date.getDay();
+	currMonth = date.getMonth();
+	currDate = date.getDate();
 	// INITIALIZING VARIABLES
 	this.updateTimeVariables = function(){
 		date = new Date();
@@ -42,12 +47,7 @@ function TimeKeeper() {
 	};
 
 	
-	// running updateTimeVariables created issues, because JavaScript, so initially updating these manually.
-	date = new Date();
-	currHour = date.getHours();
-	currDay = date.getDay();
-	currMonth = date.getMonth();
-	currDate = date.getDate();
+	
 	
 	
 	/**
@@ -59,11 +59,11 @@ function TimeKeeper() {
 		// DECLARE EVENT NAMES AND PARAMETERS
 		let events = [
 			//["<Event Name>", (<event parameters>)]
-			["Halloween", 	(timeKeeper.currMonth() === 10 	&& timeKeeper.currDate() === 31)],
-			["Christmas", 	(timeKeeper.currMonth() === 12 	&& timeKeeper.currDate() >= 24 && timeKeeper.currDate() <= 25)], 
+			["Halloween", 	(this.getMonth() === 10 	&& this.getDate() === 31)],
+			["Christmas", 	(this.getMonth() === 12 	&& this.getDate() >= 24 && cthis.getDate() <= 25)], 
 			// christmas comes before winter, to prioritize it over winter, as getEvent() returns the first event it finds.
-			["Winter", 		(timeKeeper.getMonth() >= 12 	|| timeKeeper.getMonth() <= 2)],
-			["NewYearsEve",	(timeKeeper.getMonth() === 12 	&& timeKeeper.currDate() === 31)]
+			["Winter", 		(this.getMonth() >= 12 	|| this.getMonth() <= 2)],
+			["NewYearsEve",	(this.getMonth() === 12 	&& this.getDate() === 31)]
 			//["Easter", (timeKeeper.getMonth() === && )]
 		];
 		


### PR DESCRIPTION
Creation of `TimeKeeper` was missing in AudioManager.js

In NotifiationManager.js there was a temporal dead zone with the `weather.toLowerCase()` I have fixed it so it now correctly shows the right string and does not cause an error.
also in NotificationManager.js. the check to `isEnabled()` to verify if the notifications were turned on was not being called properly. 

Getting event dates and times in TimeKeeper.js were incorrect. I have corrected them to get the correct dates and times.


