### PR TITLE
Fix: various tab audio handler bugs

### DIFF
--- a/options.html
+++ b/options.html
@@ -256,9 +256,11 @@
 				</header>
 
 				<div class="content">
-					<h3>Version 4.0.1<span class="changelog-date"> - ??th of February 2020</span></h3>
+					<h3>Version 4.0.1<span class="changelog-date"> - 12th of February 2020</span></h3>
 					<ul class="changelog-list">
 						<li>Added checks for MediaSession API fixing the issue where music would not play in some browsers and older versions of Chrome.</li>
+						<li>Fixed a bug causing the Tab Audio Handler to not work as intended on some browsers.</li>
+						<li>Fixed a bug causing the Tab Audio Handler to get stuck in the wrong state if tabs stopped playing audio while the music was paused and vice-versa.</li>
 					</ul>
 					<h3>Version 4.0.0<span class="changelog-date"> - 8th of February 2020</span></h3>
 					<ul class="changelog-list">

--- a/scripts/background/TabAudioHandler.js
+++ b/scripts/background/TabAudioHandler.js
@@ -5,7 +5,9 @@
 function TabAudioHandler() {
 
     let tabUpdatedHandler;
+    let checkTabsInterval;
     let callback;
+    let audible = false;
 
     this.activated = false;
 
@@ -25,6 +27,7 @@ function TabAudioHandler() {
             tabUpdatedHandler = checkTabs;
             chrome.tabs.onUpdated.addListener(checkTabs);
             chrome.tabs.onRemoved.addListener(checkTabs); // A tab that is audible can be closed and will not trigger the updated event.
+            checkTabsInterval = setInterval(checkTabs, 100);
             checkTabs();
         } else if (tabUpdatedHandler) removeHandler();
     }
@@ -36,7 +39,8 @@ function TabAudioHandler() {
     }
 
     function removeHandler() {
-        chrome.tabs.onUpdated.removeListener(tabUpdatedHandler);
+        if (tabUpdatedHandler) chrome.tabs.onUpdated.removeListener(tabUpdatedHandler);
+        if (checkTabsInterval) clearInterval(checkTabsInterval);
         tabUpdatedHandler = null;
     }
 
@@ -46,7 +50,11 @@ function TabAudioHandler() {
             muted: false,
             audible: true
         }, tabs => {
-            callback(tabs.length > 0);
+            let nowAudible = tabs.length > 0;
+            if (nowAudible != audible) {
+                callback(tabs.length > 0);
+                audible = nowAudible;
+            }
         });
     }
 }

--- a/scripts/background/Utility.js
+++ b/scripts/background/Utility.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var DEBUG_FLAG = false;
+var DEBUG_FLAG = true;
 
 // Returns a hour-formatted string of a time
 function formatHour(time) {

--- a/scripts/background/Utility.js
+++ b/scripts/background/Utility.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var DEBUG_FLAG = true;
+var DEBUG_FLAG = false;
 
 // Returns a hour-formatted string of a time
 function formatHour(time) {


### PR DESCRIPTION
This PR includes:
- Fixed a bug causing the Tab Audio Handler to not work as intended on some browsers. (Closes #63)
- Fixed a bug causing the Tab Audio Handler to get stuck in the wrong state if tabs stopped playing audio while the music was paused and vice-versa.