### PR TITLE
Fix: songs looping at wrong times

### DIFF
--- a/options.html
+++ b/options.html
@@ -256,11 +256,15 @@
 				</header>
 
 				<div class="content">
-					<h3>Version 4.0.1<span class="changelog-date"> - 12th of February 2020</span></h3>
+					<h3>Version 4.0.1<span class="changelog-date"> - ??th of February 2020</span></h3>
 					<ul class="changelog-list">
-						<li>Added checks for MediaSession API fixing the issue where music would not play in some browsers and older versions of Chrome.</li>
-						<li>Fixed a bug causing the Tab Audio Handler to not work as intended on some browsers.</li>
-						<li>Fixed a bug causing the Tab Audio Handler to get stuck in the wrong state if tabs stopped playing audio while the music was paused and vice-versa.</li>
+						<li>Added checks for MediaSession API fixing the issue where music would not play in some browsers and older versions of Chrome</li>
+						<li>Fixed a bug causing the Tab Audio Handler to not work as intended on some browsers</li>
+						<li>Fixed a bug causing the Tab Audio Handler to get stuck in the wrong state if tabs stopped playing audio while the music was paused and vice-versa</li>
+						<li>Clarified what country code to use</li>
+						<li>Changed zip/post code reference link</li>
+						<li>Added a note for users with a space in their post code</li>
+						<li>Fixed a bug causing songs to sometimes loop incorrectly</li>
 					</ul>
 					<h3>Version 4.0.0<span class="changelog-date"> - 8th of February 2020</span></h3>
 					<ul class="changelog-list">


### PR DESCRIPTION
Closes #68. The issue was is that the tab audio handler would pause/unpause the music during the town tune, causing it to spawn multiple loop time timeouts and other various issues. Also updated changelog. 