### PR TITLE
Update: backend domain + about page overhaul

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -33,9 +33,17 @@
     border-radius: 10px;
 }
 
+#about>header, .about-content {
+    min-width: 700px !important;
+}
+
 #contributors-failed {
     display: none;
     color: red;
+}
+
+#contributors-table {
+    vertical-align: top;
 }
 
 table {
@@ -50,7 +58,7 @@ td {
     padding: 8px;
 }
 
-.contributor {
+.contributorLink {
     text-decoration: none !important;
 }
 
@@ -59,8 +67,22 @@ td {
     margin: 6px 0 0 0;
 }
 
-.contributor>img {
+.contributor>img:first-child {
     width: 100%;
+}
+
+.contributorLink>img {
+    width: 12px;
+    vertical-align: middle;
+}
+
+.githubIcon {
+    padding-right: 3px;
+    margin-bottom: 2px;
+}
+
+.discordIcon {
+    padding-right: 2px;
 }
 
 #tab-audio-reduce-value {

--- a/manifest.json
+++ b/manifest.json
@@ -37,11 +37,11 @@
    "permissions": [
       "notifications",
       "storage",
-      "https://ac.pikadude.me/"
+      "https://acmusicext.com/"
    ],
    "optional_permissions": [
       "tabs"
    ],
    "update_url": "https://clients2.google.com/service/update2/crx",
-   "version": "4.0.1"
+   "version": "4.1.0"
 }

--- a/options.html
+++ b/options.html
@@ -215,7 +215,7 @@
 					<h1>About</h1>
 				</header>
 
-				<div class="content">
+				<div class="content about-content">
 					<div class="image-container">
 						<img src="img/icons/icon/128.png" width="48" height="48">
 						<div class="image-container-text">
@@ -253,7 +253,7 @@
 				</header>
 
 				<div class="content">
-					<h3>Version 4.0.1<span class="changelog-date"> - 13th of February 2020</span></h3>
+					<h3>Version 4.1.0<span class="changelog-date"> - 13th of February 2020</span></h3>
 					<ul class="changelog-list">
 						<li>Added checks for MediaSession API fixing the issue where music would not play in some browsers and older versions of Chrome</li>
 						<li>Fixed a bug causing the Tab Audio Handler to not work as intended on some browsers</li>
@@ -262,6 +262,8 @@
 						<li>Changed zip/post code reference link</li>
 						<li>Added a note for users with a space in their post code</li>
 						<li>Fixed a bug causing songs to sometimes loop incorrectly</li>
+						<li>Overhauled about page</li>
+						<li>Changed API endpoints and domain</li>
 					</ul>
 					<h3>Version 4.0.0<span class="changelog-date"> - 8th of February 2020</span></h3>
 					<ul class="changelog-list">

--- a/scripts/background/AudioManager.js
+++ b/scripts/background/AudioManager.js
@@ -68,7 +68,7 @@ function AudioManager(addEventListener, isTownTune) {
 		}*/
 
 		// SETTING AUDIO SOURCE		
-		audio.src = `https://ac.pikadude.me/static/${game}/${weather}/${songName}.ogg`;
+		audio.src = `https://acmusicext.com/static/${game}/${weather}/${songName}.ogg`;
 
 		let loopTime = ((loopTimes[game] || {})[weather] || {})[hour];
 		let delayToLoop;
@@ -161,7 +161,7 @@ function AudioManager(addEventListener, isTownTune) {
 		} else version = kkVersion;
 
 		let randomSong = KKSongList[Math.floor(Math.random() * KKSongList.length)];
-		audio.src = `https://ac.pikadude.me/static/kk/${version}/${randomSong}.ogg`;
+		audio.src = `https://acmusicext.com/static/kk/${version}/${randomSong}.ogg`;
 		audio.play();
 
 		let formattedTitle = `${randomSong.split(' - ')[1]} (${capitalize(version)} Version)`;

--- a/scripts/background/MediaSessionManager.js
+++ b/scripts/background/MediaSessionManager.js
@@ -74,7 +74,7 @@ function MediaSessionManager() {
 				if (name == 'kk') resolve('');
 
 				if (kk) {
-					let kkArtUrl = `https://ac.pikadude.me/static/kk/art/${name}.png`
+					let kkArtUrl = `https://acmusicext.com/static/kk/art/${name}.png`
 					printDebug(`Using fallback remote url: "${kkArtUrl}"`)
 					resolve(kkArtUrl);
 				}

--- a/scripts/background/WeatherManager.js
+++ b/scripts/background/WeatherManager.js
@@ -36,7 +36,7 @@ function WeatherManager(zip, country) {
 
 	// Checks the weather every 10 minutes, calls callback if it's changed
 	let weatherCheckLoop = function () {
-		let url = `https://ac.pikadude.me/weather/${country}/${zip}`
+		let url = `https://acmusicext.com/api/weather-v1/${country}/${zip}`
 		let request = new XMLHttpRequest();
 
 		request.onload = function () {

--- a/scripts/options/contributors.js
+++ b/scripts/options/contributors.js
@@ -1,6 +1,6 @@
 // Be sure to update this URL when the time comes.
-const projectURL = 'https://api.github.com/repos/animal-crossing-music-extension/ac-music-extension/contributors';
-const tableColCount = 6;
+const projectURL = 'https://acmusicext.com/api/contributors';
+const tableColCount = 5;
 
 function getContributors() {
     return new Promise(resolve => {
@@ -50,22 +50,63 @@ async function updateContributors() {
         for (let cI = rowI * tableColCount; cI < tableColCount + rowI * tableColCount; cI++) {
             let contributor = contributors[cI];
             let td = document.createElement('td');
+            td.className = 'contributor';
 
             if (contributor) {
-                let anchor = document.createElement('a');
-                anchor.target = "_blank";
-                anchor.href = contributor.html_url;
-                anchor.className = 'contributor';
-
                 let avatar = document.createElement('img');
                 avatar.src = contributor.avatar_url;
 
                 let name = document.createElement('p');
-                name.textContent = contributor.login;
+                name.textContent = contributor.name;
 
-                anchor.appendChild(avatar);
-                anchor.appendChild(name);
-                td.appendChild(anchor);
+                let contributions;
+                if (contributor.contributions > 0) {
+                    contributions = document.createElement('span');
+                    contributions.textContent = `${contributor.contributions} ${(contributor.contributions == 1) ? 'Contribution' : 'Contributions'}`;
+                }
+
+                let githubLink;
+                if (contributor.url) {
+                    githubLink = document.createElement('a');
+                    githubLink.target = "_blank";
+                    githubLink.href = contributor.url;
+                    githubLink.className = 'contributorLink';
+
+                    let icon = document.createElement('img');
+                    icon.src = 'img/social/github.png';
+                    icon.className = 'githubIcon';
+                    githubLink.appendChild(icon);
+
+                    githubLink.append(`@${contributor.login}`);
+                }
+
+                let discordName;
+                if (contributor.discord) {
+                    discordName = document.createElement('span');
+                    discordName.className = 'contributorLink';
+
+                    let icon = document.createElement('img');
+                    icon.src = 'img/social/discord.png';
+                    icon.className = 'discordIcon';
+                    discordName.appendChild(icon);
+
+                    discordName.append(`@${contributor.discord}`);
+                }
+
+                td.appendChild(avatar);
+                td.appendChild(name);
+                if (contributions) {
+                    td.appendChild(document.createElement('br'));
+                    td.appendChild(contributions);
+                }
+                if (githubLink) {
+                    td.appendChild(document.createElement('br'));
+                    td.appendChild(githubLink);
+                }
+                if (discordName) {
+                    td.appendChild(document.createElement('br'));
+                    td.appendChild(discordName);
+                }
             }
 
             row.appendChild(td);

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -231,7 +231,7 @@ function validateWeather() {
 		return;
 	}
 
-	let url = `https://ac.pikadude.me/weather/${country}/${zip}`;
+	let url = `https://acmusicext.com/api/weather-v1/${country}/${zip}`;
 	let request = new XMLHttpRequest();
 
 	request.onload = function () {


### PR DESCRIPTION
- Updated the domain to our proper one instead of my one. This will cause the extension to get disabled again until users approve the change of permissions, which is an annoyance, but it's better that we do it earlier rather than later. The old domain will still function with everything until it seems that everyone has updated to the new one.
- Overhauled the about page to list ALL contributors, even the anonymous ones, which I managed to manually track down. It also now lists contributions and contributor Discord names, when applicable.
- Pushed the version number from 4.0.1 to 4.1.0, I'd say that these are pretty big changes and deserve to be considered a minor update rather than a patch.