### PR TITLE
Fix: timekeeper's hourly check function

### DIFF
--- a/options.html
+++ b/options.html
@@ -262,6 +262,7 @@
 						<li>Changed zip/post code reference link</li>
 						<li>Added a note for users with a space in their post code</li>
 						<li>Fixed a bug causing songs to sometimes loop incorrectly</li>
+						<li>Fixed a bug causing the music to not click over to the next hour and get stuck on a single hour</li>
 					</ul>
 					<h3>Version 4.0.0<span class="changelog-date"> - 8th of February 2020</span></h3>
 					<ul class="changelog-list">

--- a/scripts/background/TimeKeeper.js
+++ b/scripts/background/TimeKeeper.js
@@ -78,10 +78,8 @@ function TimeKeeper() {
 	
 	
 	
-	var timeCheckLoop = function() {
+	function timeCheck() {
 		var newDate = new Date();
-		var timeToNext = 3600000 - (newDate.getTime() % 3600000);
-		setTimeout(timeCheckLoop, timeToNext);
 		currDay = newDate.getDay();
 		// if we're in a new hour
 		if (newDate.getHours() != currHour) {
@@ -92,6 +90,5 @@ function TimeKeeper() {
 		}
 	}
 
-	timeCheckLoop();
-
+	setInterval(timeCheck, 1000);
 }


### PR DESCRIPTION
Previously, timekeeper used to create a timeout function that would wait specifically until the hour ticks over to register the hourly change, and therefore change the music. This process is flawed in several ways:
- SetTimeout can become desynced in a way and slowly become wrong. If you were to have a SetTimeout function wait exactly 24 hours for example, you may wait slightly more or slightly less than exactly 24 hours.
- Doing specific tasks, such as putting the computer to sleep, will pause the SetTimeout. When the computer wakes up, the SetTimeout will resume, but will be desynced from the current time (e.g. put the computer to sleep at 2:43pm, wake it up a few hours later, and it will continue to play the 2pm loop for another 17 minutes).
- Some specific tasks can also completely break the SetTimeout causing it to never actually run. I'm not sure of any specifics of this, but I am aware of this being able to happen, causing the music to get permanently stuck.

I have updated the function to a SetInterval loop that runs every second, fixing all of the above issues, by running every second, and not waiting until a specific time, which will prevent it from getting desynced.