### PR TITLE
Add: option to pause music when browser is closed

### DIFF
--- a/options.html
+++ b/options.html
@@ -143,18 +143,6 @@
 					</section>
 
 					<section>
-						<h3>Notifications</h3>
-						<p>Customize desktop notification behaviour</p>
-						<div class="checkbox">
-							<input id="enable-notifications" type="checkbox"><label for="enable-notifications"><span></span>Enable Chrome notifications on song change</label>
-						</div>
-
-						<div class="checkbox">
-							<input id="enable-badge" type="checkbox"><label for="enable-badge"><span></span>Display text on badge</label>
-						</div>
-					</section>
-
-					<section>
 						<h3>Tab Audio Behaviour</h3>
 						<p>Control what the extension does while a tab is playing audio</p>
 						<div class="radio" style="height: 21px">
@@ -167,6 +155,22 @@
 						</div>
 						<div class="radio">
 							<input id="tab-audio-nothing" name="tab-audio" type="radio"><label for="tab-audio-nothing"><span><span></span></span>Do nothing</label>
+						</div>
+					</section>
+
+					<section>
+						<h3>Other</h3>
+						<p>Other various options that don't fit in any other category</p>
+						<div class="checkbox">
+							<input id="enable-notifications" type="checkbox"><label for="enable-notifications"><span></span>Enable Chrome notifications on song change</label>
+						</div>
+
+						<div class="checkbox">
+							<input id="enable-badge" type="checkbox"><label for="enable-badge"><span></span>Display text on badge</label>
+						</div>
+
+						<div class="checkbox">
+							<input id="enable-background" type="checkbox"><label for="enable-background"><span></span>Allow for music to play when Chrome is closed. <a target="_blank" href="https://kb.nmsu.edu/73071">Background apps must also be enabled in Chrome's settings.</a></label>
 						</div>
 					</section>
 
@@ -262,6 +266,7 @@
 						<li>Changed zip/post code reference link</li>
 						<li>Added a note for users with a space in their post code</li>
 						<li>Fixed a bug causing songs to sometimes loop incorrectly</li>
+						<li>Added a built-in option to stop the extension from playing music when Chrome is closed</li>
 					</ul>
 					<h3>Version 4.0.0<span class="changelog-date"> - 8th of February 2020</span></h3>
 					<ul class="changelog-list">

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -17,6 +17,7 @@ const onClickElements = [
 	'absolute-town-tune',
 	'enable-notifications',
 	'enable-badge',
+	'enable-background',
 	'kk-version-live',
 	'kk-version-aircheck',
 	'kk-version-both',
@@ -106,6 +107,7 @@ function saveOptions() {
 	let zipCode = document.getElementById('zip-code').value;
 	let countryCode = document.getElementById('country-code').value;
 	let enableBadgeText = document.getElementById('enable-badge').checked;
+	let enableBackground = document.getElementById('enable-background').checked;
 	let tabAudioReduceValue = document.getElementById('tab-audio-reduce-value').value;
 
 	if (tabAudioReduceValue > 100) {
@@ -164,6 +166,7 @@ function saveOptions() {
 		zipCode,
 		countryCode,
 		enableBadgeText,
+		enableBackground,
 		tabAudio,
 		tabAudioReduceValue
 	});
@@ -183,6 +186,7 @@ function restoreOptions() {
 		zipCode: "98052",
 		countryCode: "us",
 		enableBadgeText: true,
+		enableBackground: false,
 		tabAudio: 'nothing',
 		tabAudioReduceValue: 80
 	}, items => {
@@ -200,6 +204,7 @@ function restoreOptions() {
 		document.getElementById('zip-code').value = items.zipCode;
 		document.getElementById('country-code').value = items.countryCode;
 		document.getElementById('enable-badge').checked = items.enableBadgeText;
+		document.getElementById('enable-background').checked = items.enableBackground;
 		document.getElementById('tab-audio-' + items.tabAudio).checked = true;
 		document.getElementById('tab-audio-reduce-value').value = items.tabAudioReduceValue;
 


### PR DESCRIPTION
A lot of complaints (mainly from mac users) is that the extension keeps playing music even when the browser is closed.

On Windows, there's an option in Chrome itself, to "Continue running background apps when Google Chrome is closed", which is enabled by default. Turning this off solves the issue, and the extension stops playing music when the browser's closed, although, not all users know of this option and we have also received complaints from Windows users too.

On Mac, there's no such option, and the only "solution", is to force close Chrome every time. Because of this, Mac users really don't have a way to stop the extension from playing when the browser's closed. They have to manually pause it and resume every time they close and open Chrome.

This new in-built option solves both of these issues.