### PR TITLE
Update: remove need for tabs permission

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -89,7 +89,7 @@ td {
     width: 50%;
 }
 
-.modal-title {
+#modal-title {
     font-weight: bold;
     font-size: 18px;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -39,9 +39,6 @@
       "storage",
       "https://ac.pikadude.me/"
    ],
-   "optional_permissions": [
-      "tabs"
-   ],
    "update_url": "https://clients2.google.com/service/update2/crx",
    "version": "4.0.1"
 }

--- a/options.html
+++ b/options.html
@@ -262,6 +262,7 @@
 						<li>Changed zip/post code reference link</li>
 						<li>Added a note for users with a space in their post code</li>
 						<li>Fixed a bug causing songs to sometimes loop incorrectly</li>
+						<li>Removed the need for the tabs permission for the Tab Audio Behaviour/Handling function</li>
 					</ul>
 					<h3>Version 4.0.0<span class="changelog-date"> - 8th of February 2020</span></h3>
 					<ul class="changelog-list">

--- a/options.html
+++ b/options.html
@@ -302,14 +302,12 @@
 
 	<div id="tabAudioModal" class="modal">
 		<div class="modal-content">
-			<p class="modal-title">Note!</p>
-			<p>The "Tab Audio Behaviour" option requires additional permissions to function, specifically the "Tabs" permission. Due to a quirk in Chromium, this permission is defined
-				as "Read your browsing history". This permission does NOT give the extension permission to view your actual browsing history, but allows it to see what tabs you currently
-				have open, which we use ONLY to check to see if any tabs are playing audio. If you are okay with that, press "Allow" on the next dialogue.</p>
-			<a target="_blank" href="https://developer.chrome.com/extensions/permission_warnings#view_warnings">For more info, refer to the Chrome Developer Docs.</a>
+			<p id="modal-title"></p>
+			<p id="modal-text"></p>
+			<a id="modal-link" target="_blank"></a>
 			<br />
 			<br />
-			<button id="tabAudioModalDismiss">Understood!</button>
+			<button id="tabAudioModalDismiss"></button>
 		</div>
 	</div>
 </body>

--- a/options.html
+++ b/options.html
@@ -263,6 +263,7 @@
 						<li>Added a note for users with a space in their post code</li>
 						<li>Fixed a bug causing songs to sometimes loop incorrectly</li>
 						<li>Removed the need for the tabs permission for the Tab Audio Behaviour/Handling function</li>
+						<li>Change default Tab Audio Behaviour to pause rather than nothing</li>
 					</ul>
 					<h3>Version 4.0.0<span class="changelog-date"> - 8th of February 2020</span></h3>
 					<ul class="changelog-list">

--- a/scripts/background/StateManager.js
+++ b/scripts/background/StateManager.js
@@ -98,7 +98,7 @@ function StateManager() {
 			zipCode: "98052",
 			countryCode: "us",
 			enableBadgeText: true,
-			tabAudio: 'nothing',
+			tabAudio: 'pause',
 			tabAudioReduceValue: 80
 		}, items => {
 			options = items;

--- a/scripts/background/StateManager.js
+++ b/scripts/background/StateManager.js
@@ -193,10 +193,6 @@ function StateManager() {
 	// play/pause when user clicks the extension icon
 	chrome.browserAction.onClicked.addListener(toggleMusic);
 
-	// update tab audio handler when the user changes the extension's permissions
-	chrome.permissions.onAdded.addListener(tabAudio.activate);
-	chrome.permissions.onRemoved.addListener(tabAudio.activate);
-
 	tabAudio.registerCallback(audible => {
 		notifyListeners("tabAudio", [audible, options.tabAudio, options.tabAudioReduceValue]);
 	});

--- a/scripts/background/TabAudioHandler.js
+++ b/scripts/background/TabAudioHandler.js
@@ -19,23 +19,13 @@ function TabAudioHandler() {
         printDebug("Activating TabAudioHandler.");
 
         this.activated = true;
-        let perms = await checkPerms();
-        printDebug(perms);
 
-        if (perms) {
-            if (tabUpdatedHandler) removeHandler();
-            tabUpdatedHandler = checkTabs;
-            chrome.tabs.onUpdated.addListener(checkTabs);
-            chrome.tabs.onRemoved.addListener(checkTabs); // A tab that is audible can be closed and will not trigger the updated event.
-            checkTabsInterval = setInterval(checkTabs, 100);
-            checkTabs();
-        } else if (tabUpdatedHandler) removeHandler();
-    }
-
-    function checkPerms () {
-        return new Promise(resolve => {
-            chrome.permissions.contains({ permissions: ['tabs'] }, resolve);
-        });
+        if (tabUpdatedHandler) removeHandler();
+        tabUpdatedHandler = checkTabs;
+        chrome.tabs.onUpdated.addListener(checkTabs);
+        chrome.tabs.onRemoved.addListener(checkTabs); // A tab that is audible can be closed and will not trigger the updated event.
+        checkTabsInterval = setInterval(checkTabs, 100);
+        checkTabs();
     }
 
     function removeHandler() {

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -20,13 +20,10 @@ const onClickElements = [
 	'kk-version-live',
 	'kk-version-aircheck',
 	'kk-version-both',
-	'tab-audio-nothing'
-];
-
-const tabAudioElements = [
+	'tab-audio-nothing',
 	'tab-audio-reduce',
 	'tab-audio-pause'
-]
+];
 
 const exclamationElements = [
 	'live-weather-location-link',
@@ -58,28 +55,6 @@ window.onload = function () {
 
 	onClickElements.forEach(el => {
 		document.getElementById(el).onclick = saveOptions;
-	});
-	tabAudioElements.forEach(el => {
-		document.getElementById(el).onclick = () => {
-			chrome.permissions.contains({ permissions: ['tabs'] }, hasTabs => {
-				if (hasTabs) saveOptions();
-				else {
-					let modal = document.getElementById('tabAudioModal');
-					modal.style.display = 'block';
-
-					document.getElementById('tabAudioModalDismiss').onclick = () => {
-						modal.style.display = "none";
-						chrome.permissions.request({ permissions: ['tabs'] }, hasTabs => {
-							if (hasTabs) saveOptions();
-							else {
-								tabAudioElements.forEach(el => document.getElementById(el).checked = false);
-								document.getElementById('tab-audio-nothing').checked = true;
-							}
-						});
-					};
-				}
-			});
-		}
 	});
 	document.getElementById('update-location').onclick = validateWeather;
 	document.getElementById('tab-audio-reduce-value').onchange = saveOptions;

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -158,7 +158,7 @@ function restoreOptions() {
 		zipCode: "98052",
 		countryCode: "us",
 		enableBadgeText: true,
-		tabAudio: 'nothing',
+		tabAudio: 'pause',
 		tabAudioReduceValue: 80
 	}, items => {
 		document.getElementById('volume').value = items.volume;


### PR DESCRIPTION
So I'm an idiot and thought we needed the "tabs" permission to check if tabs were playing audio. Nope I'm just a complete fool, we don't. At all. This PR completely removes it and changes the default tab audio behaviour option from "nothing" to "pause".