### PR TITLE
Enhancements & additions to the town tune editor & player

### DIFF
--- a/css/input.css
+++ b/css/input.css
@@ -20,6 +20,7 @@ section {
   
   border-width: 3px !important;
   border-radius: 40px !important;
+  transition-duration: 0.1s;
 }
 
 .pitch-slider {

--- a/css/input.css
+++ b/css/input.css
@@ -10,18 +10,20 @@ section {
 .pitch {
   display: inline-block;
   width: 25px;
-  margin:5px;
+  margin: 6px;
 }
 
 .pitch-name {
   text-align: center;
-  width: 40px;
+  width: 35px;
+  height: 35px;
+  
+  border-width: 3px !important;
+  border-radius: 40px !important;
 }
 
 .pitch-slider {
   -webkit-appearance: slider-vertical;
-  width: 25px;
-  height: 75px;
 }
 
 button, input[type='text']:not(.pitch-name) {
@@ -54,10 +56,18 @@ input[type="text"]#weather {
 }
 
 input[type="range"]#volume{
-    -webkit-appearance: none;
+  -webkit-appearance: none;
 	width: 129px;
 	height: 3px;
-    background-color: #e3ddd8; 
+  background-color: #e3ddd8; 
+}
+
+input[type="range"]#townTuneVolume{
+  -webkit-appearance: none;
+  width: 240px;
+  height: 3px;
+  background-color: #e3ddd8; 
+  
 }
 
 

--- a/options.html
+++ b/options.html
@@ -208,7 +208,7 @@
 						<div class="controls">
 							<button class="play-tune">Play!</button>
 							<div class="spacer"></div>
-							<button class="reset-tune">Reset</button>
+							<button class="reset-tune">Reset to Default</button>
 							<button class="randomize-tune">Randomize</button>
 							<div class="spacer"></div>
 							<button class="save-tune">Save</button>

--- a/options.html
+++ b/options.html
@@ -192,17 +192,24 @@
 					<section>
 						<p>Compose a tune to be played every hour on the hour</p>
 						<div class="pitch-template hidden">
-							<input class="pitch-name" type="text" maxlength="2" size="2">
-							<input class="pitch-slider" type="range" min="0" max="14" step="1" orient="vertical">
+							<input class="pitch-name"   type="text"  maxlength="2" size="2">
+							<input class="pitch-slider" type="range" min="0" max="16" step="1" orient="vertical">
 						</div>
 						<div class="staff staff1"></div>
 						<div class="staff staff2"></div>
+						<br>
+						<p>Town tune volume:</p>
+						<input id="townTuneVolume" type="range" min="0" max="1" step="0.01">
+						<span  id="townTuneVolumeText"></span> 
 					</section>
-
+					
 					<header>
 						<div style="padding: 0; margin: 0; height:18px;"></div>
 						<div class="controls">
 							<button class="play-tune">Play!</button>
+							<div class="spacer"></div>
+							<button class="reset-tune">Reset</button>
+							<button class="randomize-tune">Randomize</button>
 							<div class="spacer"></div>
 							<button class="save-tune">Save</button>
 						</div>

--- a/scripts/background/StateManager.js
+++ b/scripts/background/StateManager.js
@@ -94,6 +94,7 @@ function StateManager() {
 			paused: false,
 			enableTownTune: true,
 			absoluteTownTune: false,
+			townTuneVolume: 0.75,
 			//enableAutoPause: false,
 			zipCode: "98052",
 			countryCode: "us",

--- a/scripts/background/TownTuneManager.js
+++ b/scripts/background/TownTuneManager.js
@@ -6,11 +6,11 @@
 
 function TownTuneManager() {
 
-	var defaultTune = ["G2", "E3", "-", "G2", "F2", "D3", "-", "B2", "C3", "zZz", "C2", "-", "C2", "-", "-", "zZz"];
+	var defaultTune = ["C2", "E2", "C2", "G1", "F1", "G1", "B1", "D2", "C2", "zZz", "G1", "zZz", "C2", "-", "-", "zZz"];
 	var audioContext = new AudioContext();
 	var sampler = createSampler(audioContext);
 	var tunePlayer = createTunePlayer(audioContext);
-
+	
 	// Play tune and call doneCB after it's done
 	this.playTune = function(doneCB) {
 		chrome.storage.sync.get({ townTune: defaultTune }, function(items){

--- a/scripts/global/tune_player.js
+++ b/scripts/global/tune_player.js
@@ -4,7 +4,7 @@
   // ^ values in HZ
   
   var _defaultTownTuneVolume = 0.75;
-  var timeBetweenTuneEndAndMusicBegin = 1; // Used at line 230
+  var timeBetweenTuneEndAndMusicBeginS = 2; // In Seconds. Delays createTunePlayer.playTune()'s callback.
   
   /**
    * @function createBooper
@@ -72,11 +72,11 @@
       chrome.storage.sync.get({townTuneVolume: _defaultTownTuneVolume}, function(items){
         let volume = items.townTuneVolume;
         
-        gain.gain.setValueAtTime         (0,                  time);
+        gain.gain.setValueAtTime         (0,                     time);
         gain.gain.linearRampToValueAtTime(gainLevel    * volume, time + attack);
         gain.gain.linearRampToValueAtTime(sustainLevel * volume, time + attack + decay);
         gain.gain.setValueAtTime         (sustainLevel * volume, time + attack + decay + sustainDuration);
-        gain.gain.linearRampToValueAtTime(0,                  time + attack + decay + sustainDuration + release);
+        gain.gain.linearRampToValueAtTime(0,                     time + attack + decay + sustainDuration + release);
         
       });
     };
@@ -227,7 +227,7 @@ var createTunePlayer = function(audioContext, bpm) {
       },
       done: function(callback) {
         //when the tune over
-        if (callback) setTimeout(callback, stepDuration * tune.length * 1000 + timeBetweenTuneEndAndMusicBegin * 1000);
+        if (callback) setTimeout(callback, stepDuration * tune.length * 1000 + timeBetweenTuneEndAndMusicBeginS * 1000);
         return callbacks;
       }
     };

--- a/scripts/global/tune_player.js
+++ b/scripts/global/tune_player.js
@@ -219,19 +219,22 @@ var createTunePlayer = function(audioContext, bpm) {
       // Look at createBooper.playNote() method for a way to implement sustain in createSampler.playNote().
     }
 
-    //jQuery stlye chain callbacks
-    callbacks = {
-      eachNote: function(callback) {
-        eachNote = callback;
-        return callbacks;
-      },
-      done: function(callback) {
-        //when the tune over
-        if (callback) setTimeout(callback, stepDuration * tune.length * 1000);
-        return callbacks;
-      }
-    };
-    return callbacks;
+    // Slight delay to fix jarring introduction to song after town tune has played
+    setTimeout(function(){
+      //jQuery stlye chain callbacks
+      callbacks = {
+        eachNote: function(callback) {
+          eachNote = callback;
+          return callbacks;
+        },
+        done: function(callback) {
+          //when the tune over
+          if (callback) setTimeout(callback, stepDuration * tune.length * 1000);
+          return callbacks;
+        }
+      };
+      return callbacks;
+    }, 500);
   };
 
   return tunePlayer = {

--- a/scripts/global/tune_player.js
+++ b/scripts/global/tune_player.js
@@ -1,78 +1,102 @@
 (function() {
-  var availablePitches = ['zZz', '-', 'G1', 'A1', 'B1', 'C2', 'D2', 'E2', 'F2', 'G2', 'A2', 'B2', 'C3', 'D3', 'E3'];
+  var availablePitches = ['zZz', '-', 'F1', 'G1', 'A1', 'B1', 'C2', 'D2', 'E2', 'F2', 'G2', 'A2', 'B2', 'C3', 'D3', 'E3', '?'];
+  var frequencies      = [null,  null, 350,  392,  440,  494,  523,  587,  659,  698,  784,  880,  988, 1046, 1174, 1318, "random"];
+  // ^ values in HZ
+  
+  var _defaultTownTuneVolume = 0.75;
+  
+  
+  /**
+   * @function createBooper
+   * @desc  Creates & returns method responsible for playing town-tune notes in the town-tune editor
+   * @param {*} audioContext 
+   * @returns {method} playNote
+   */
+  var createBooper = function(audioContext) { 
+    
+    var attack = 0.05;  //in seconds
+    var decay = 0.1;    //in seconds
+    var release = 0.15; //in seconds
+    var gainLevel = 3;
+    var sustainLevel = 2;
+    var cutoffModifier = 8;
+    var Q = 0; 
+    
+    
+    var pitchToFreq = function(pitch) {
+      if (typeof pitch == 'number') return pitch;
+      
+      index = availablePitches.indexOf(pitch);
+      if (index == -1) return null; // Pitch does not exist in register
+      
+      var freq = frequencies[index];
+      
+      // Generating random frequency
+      if(freq == "random") freq = frequencies[ 2 + Math.floor( Math.random() * (frequencies.length - 3) ) ];  
+      
+      if (!freq) return null; // Pitch not assigned to a frequency
 
+      return freq;
+    };
 
-var createBooper = function(audioContext) {
-  //values in HZ
-  var frequencies = [null, null, 392, 440, 494, 523, 587, 659, 698, 784, 880, 988, 1046, 1174, 1318];
+    var playNote = function(pitch, time, sustainDuration) {
+      if (time === undefined) time = audioContext.currentTime;
+      if (sustainDuration === undefined) sustainDuration = 0;
 
-  var attack = 0.05; //in seconds
-  var decay = 0.1; //in seconds
-  var release = 0.15; //in seconds
-  var gainLevel = 3;
-  var sustainLevel = 2;
-  var cutoffModifier = 8;
-  var Q = 0;
+      var freq = pitchToFreq(pitch);
+      if (!freq) return;
 
-  var pitchToFreq = function(pitch) {
-    if (typeof pitch == 'number') return pitch;
+      var oscillator, filter, gain;
 
-    index = availablePitches.indexOf(pitch);
-    if (index == -1) return null;
+      oscillator = audioContext.createOscillator();
+      oscillator.type = 'square';
+      oscillator.frequency.value = freq;
 
-    var freq = frequencies[index]
-    if (!freq) return null;
+      filter = audioContext.createBiquadFilter();
+      filter.type = 'lowpass';
+      //filter tracks the note being played
+      filter.frequency.value = Math.sqrt(freq) * cutoffModifier;
+      filter.Q.value = Q;
 
-    return freq;
+      gain = audioContext.createGain();
+      gain.gain.value = 0;
+
+      oscillator.connect(filter);
+      filter.connect(gain);
+      gain.connect(audioContext.destination);
+
+      oscillator.start(time);
+      oscillator.stop(time + attack + decay + sustainDuration + release);
+
+      // Fetching stored or default town tune volume
+      chrome.storage.sync.get({townTuneVolume: _defaultTownTuneVolume}, function(items){
+        let volume = items.townTuneVolume;
+        
+        gain.gain.setValueAtTime         (0,                  time);
+        gain.gain.linearRampToValueAtTime(gainLevel    * volume, time + attack);
+        gain.gain.linearRampToValueAtTime(sustainLevel * volume, time + attack + decay);
+        gain.gain.setValueAtTime         (sustainLevel * volume, time + attack + decay + sustainDuration);
+        gain.gain.linearRampToValueAtTime(0,                  time + attack + decay + sustainDuration + release);
+        
+      });
+    };
+
+    return {
+      playNote: playNote
+    }
   };
 
-  var playNote = function(pitch, time, sustainDuration) {
-    if (time === undefined) time = audioContext.currentTime;
-    if (sustainDuration === undefined) sustainDuration = 0;
-
-    var freq = pitchToFreq(pitch);
-    if (!freq) return;
-
-    var oscillator, filter, gain;
-
-    oscillator = audioContext.createOscillator();
-    oscillator.type = 'square';
-    oscillator.frequency.value = freq;
-
-    filter = audioContext.createBiquadFilter();
-    filter.type = 'lowpass';
-    //filter tracks the note being played
-    filter.frequency.value = Math.sqrt(freq) * cutoffModifier;
-    filter.Q.value = Q;
-
-    gain = audioContext.createGain();
-    gain.gain.value = 0;
-
-    oscillator.connect(filter);
-    filter.connect(gain);
-    gain.connect(audioContext.destination);
-
-    oscillator.start(time);
-    oscillator.stop(time + attack + decay + sustainDuration + release);
-
-    gain.gain.setValueAtTime(0, time);
-    gain.gain.linearRampToValueAtTime(gainLevel, time + attack);
-    gain.gain.linearRampToValueAtTime(sustainLevel, time + attack + decay);
-    gain.gain.setValueAtTime(sustainLevel, time + attack + decay + sustainDuration);
-    gain.gain.linearRampToValueAtTime(0, time + attack + decay + sustainDuration + release);
-  };
-
-  return {
-    playNote: playNote
-  }
-};
-
-
+  
+/**
+ * @function createSampler
+ * @desc  Creates & (?) returns method responsible for playing notes used to play the town tune at the hour
+ * @param {*} audioContext 
+ * @returns {method} playNote
+ */
 var createSampler = function(audioContext) {
   var bellBuffer;
   var startPoints = [null, null];
   var chimeLength = 3.8;
-  var volume = 0.2;
 
   var pitchToStartPoint = function(pitch) {
     index = availablePitches.indexOf(pitch);
@@ -99,22 +123,33 @@ var createSampler = function(audioContext) {
   };
 
   var initStartPoints = function() {
-    for (var i = 0; i < availablePitches.length - 2; i++) {
+    for (var i = 0; i < availablePitches.length; i++) {
       startPoints.push(i * 4);
     }
   };
 
-  var playNote = function(pitch, time, sustain) {
+  var playNote = function(pitch, time, sustain) {  //Sustain parameter isn't used here (unlike at createBooper.playNote)
     if (!bellBuffer) return;
     var source = audioContext.createBufferSource();
     source.buffer = bellBuffer;
-
-    gain = audioContext.createGain();
-    gain.gain.value = volume;
-
-    source.connect(gain);
-    gain.connect(audioContext.destination);
-    source.start(time, pitchToStartPoint(pitch), chimeLength);
+    
+    // If pitch is '?', randomizing pitch
+    if(pitch == '?') pitch = availablePitches[ 2 + Math.floor( Math.random() * (availablePitches.length - 3) ) ]
+    
+    // Fetching volume
+    chrome.storage.sync.get({townTuneVolume: _defaultTownTuneVolume}, function(items){
+      let volume = items.townTuneVolume * 0.5;
+      // The notes sound broken & not accurate to the editor's volume when played at higher volumes, vol is therefore reduced with this multiplier.
+      
+      // Configuring gain
+      gain = audioContext.createGain();
+      gain.gain.value = volume;
+      
+      // Playing audio
+      source.connect(gain);
+      gain.connect(audioContext.destination);
+      source.start(time, pitchToStartPoint(pitch), chimeLength); 
+    });
   };
 
   initStartPoints();
@@ -126,6 +161,14 @@ var createSampler = function(audioContext) {
 };
 
 
+
+/**
+ * @function createTunePlayer
+ * @desc  Creates & returns object responsible for handling the playing of town tunes at the hour.
+ * @param {*} audioContext 
+ * @param {*} bpm 
+ * @returns {object} tunePlayer 
+ */
 var createTunePlayer = function(audioContext, bpm) {
   var defaultBpm = 240.0; // BPM
   var stepDuration;
@@ -170,7 +213,10 @@ var createTunePlayer = function(audioContext, bpm) {
       if(pitch == rest || pitch == sustain) continue;
 
       sustainDuration = getSustainMultiplier(i, tune) * stepDuration;
-      instrument.playNote(pitch, audioContext.currentTime + time, sustainDuration);
+      // Plays a note using createSampler.playNote() method
+      instrument.playNote(pitch, audioContext.currentTime + time, sustainDuration); 
+      // The sustain parameter is however, not used. 
+      // Look at createBooper.playNote() method for a way to implement sustain in createSampler.playNote().
     }
 
     //jQuery stlye chain callbacks

--- a/scripts/global/tune_player.js
+++ b/scripts/global/tune_player.js
@@ -4,7 +4,7 @@
   // ^ values in HZ
   
   var _defaultTownTuneVolume = 0.75;
-  
+  var timeBetweenTuneEndAndMusicBegin = 1; // Used at line 230
   
   /**
    * @function createBooper
@@ -219,22 +219,19 @@ var createTunePlayer = function(audioContext, bpm) {
       // Look at createBooper.playNote() method for a way to implement sustain in createSampler.playNote().
     }
 
-    // Slight delay to fix jarring introduction to song after town tune has played
-    setTimeout(function(){
-      //jQuery stlye chain callbacks
-      callbacks = {
-        eachNote: function(callback) {
-          eachNote = callback;
-          return callbacks;
-        },
-        done: function(callback) {
-          //when the tune over
-          if (callback) setTimeout(callback, stepDuration * tune.length * 1000);
-          return callbacks;
-        }
-      };
-      return callbacks;
-    }, 500);
+    //jQuery stlye chain callbacks
+    callbacks = {
+      eachNote: function(callback) {
+        eachNote = callback;
+        return callbacks;
+      },
+      done: function(callback) {
+        //when the tune over
+        if (callback) setTimeout(callback, stepDuration * tune.length * 1000 + timeBetweenTuneEndAndMusicBegin * 1000);
+        return callbacks;
+      }
+    };
+    return callbacks;
   };
 
   return tunePlayer = {

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -55,6 +55,11 @@ window.onload = function () {
 		let volumeText = document.getElementById('volumeText');
 		volumeText.innerHTML = `${formatPercentage(this.value*100)}`;
 	};
+	document.getElementById('townTuneVolume').onchange = saveOptions; // Maybe disable as to only save when clicking "save" button
+	document.getElementById('townTuneVolume').oninput = function() {
+		let ttVolumeText = document.getElementById('townTuneVolumeText');
+		ttVolumeText.innerHTML = `${formatPercentage(this.value*100)}`;
+	};
 
 	onClickElements.forEach(el => {
 		document.getElementById(el).onclick = saveOptions;
@@ -103,6 +108,7 @@ function saveOptions() {
 	let enableKK = alwaysKK || document.getElementById('enable-kk').checked;
 	let enableTownTune = document.getElementById('enable-town-tune').checked;
 	let absoluteTownTune = document.getElementById('absolute-town-tune').checked;
+	let townTuneVolume   = document.getElementById('townTuneVolume').value;
 	let zipCode = document.getElementById('zip-code').value;
 	let countryCode = document.getElementById('country-code').value;
 	let enableBadgeText = document.getElementById('enable-badge').checked;
@@ -161,6 +167,7 @@ function saveOptions() {
 		kkVersion,
 		enableTownTune,
 		absoluteTownTune,
+		townTuneVolume,
 		zipCode,
 		countryCode,
 		enableBadgeText,
@@ -180,6 +187,7 @@ function restoreOptions() {
 		kkVersion: 'live',
 		enableTownTune: true,
 		absoluteTownTune: false,
+		townTuneVolume: 0.75,
 		zipCode: "98052",
 		countryCode: "us",
 		enableBadgeText: true,
@@ -197,6 +205,8 @@ function restoreOptions() {
 		document.getElementById('kk-version-' + items.kkVersion).checked = true;
 		document.getElementById('enable-town-tune').checked = items.enableTownTune;
 		document.getElementById('absolute-town-tune').checked = items.absoluteTownTune;
+		document.getElementById('townTuneVolume').value = items.townTuneVolume;
+		document.getElementById('townTuneVolumeText').innerHTML = `${formatPercentage(items.townTuneVolume*100)}`;
 		document.getElementById('zip-code').value = items.zipCode;
 		document.getElementById('country-code').value = items.countryCode;
 		document.getElementById('enable-badge').checked = items.enableBadgeText;
@@ -213,6 +223,7 @@ function restoreOptions() {
 		document.getElementById('weather-selection').querySelectorAll('input').forEach(updateChildrenState.bind(null, items.alwaysKK));
 		document.getElementById('kk-version-selection').querySelectorAll('input').forEach(updateChildrenState.bind(null, enabledKKVersion));
 	});
+	
 }
 
 function validateWeather() {

--- a/scripts/options/tune_editor.js
+++ b/scripts/options/tune_editor.js
@@ -194,7 +194,7 @@ var updateColor = function(index, pitch){
 
 var updateTune = function(index, pitch) {
   tune[index] = pitch;
-  booper.playNote(pitch, undefined, undefined, townTuneVolume);
+  booper.playNote(pitch);
 };
 
 window.addEventListener('load', setup);

--- a/scripts/options/tune_editor.js
+++ b/scripts/options/tune_editor.js
@@ -87,6 +87,8 @@ var initControls = function() {
   }
 
   editorControls.push(playButton);
+  editorControls.push(resetButton);
+  editorControls.push(randomizeButton);
 };
 
 var disableEditor = function() {
@@ -172,8 +174,11 @@ var saveTune = function() {
     saveButton.textContent = 'Saving...';
     saveButton.disabled = true;
     setTimeout(function() {
-      saveButton.textContent = 'Saved';
+      saveButton.textContent = 'Saved!';
       saveButton.disabled = false;
+      setTimeout(function() {
+        saveButton.textContent = 'Save';
+      }, 2000);
     }, 750);
   });
 };

--- a/scripts/options/tune_editor.js
+++ b/scripts/options/tune_editor.js
@@ -1,18 +1,21 @@
-(function(){
+$(function(){
 var pitchTemplate, playButton, saveButton, tune;
-var defaultTune = ["G2", "E3", "-", "G2", "F2", "D3", "-", "B2", "C3", "zZz", "C2", "zZz", "C2", "-", "-", "zZz"];
+const defaultTune = ["C2", "E2", "C2", "G1", "F1", "G1", "B1", "D2", "C2", "zZz", "G1", "zZz", "C2", "-", "-", "zZz"]; // From AC : Wild World. Old default: ["G2", "E3", "-", "G2", "F2", "D3", "-", "B2", "C3", "zZz", "C2", "zZz", "C2", "-", "-", "zZz"];
 var tuneLength = 16;
-var availableColors = ["#a4a2d0", "#e4b3d3", "#5eccf5", "#12fee0", "#53fd8a", "#79fc4e", "#a8fd35", "#d0fe47", 
-									"#e4fd39", "#f9fe2e", "#fefa43", "#fef03f", "#fcd03a", "#fcb141", "#fe912e"];
+var availableColors = ["#a4a2d0", "#e4b3d3", "#5eccf5", "#12fee0", "#53fd8a", "#79fc4e", "#a8fd35", "#d0fe47", "#e4fd39", 
+                       "#f9fe2e", "#fefa43", "#fef03f", "#fcd03a", "#fcb141", "#fe912e", "#FE672E", "#FA5C90", "#ba32a4"];
 var editorControls = [];
 var pitchNames = [];
 var flashColor = '#FFFFFF';
 var audioContext = new AudioContext;
+
 var booper = createBooper(audioContext);
 var sampler = createSampler(audioContext);
 var tunePlayer = createTunePlayer(audioContext);
 var availablePitches = tunePlayer.availablePitches;
 var rest = availablePitches[0];
+
+$(".pitch-template > .pitch-slider")[0].max = availablePitches.length-1;
 
 var createPitchControl = function(index) {
   var pitch = pitchTemplate.cloneNode(true);
@@ -23,13 +26,15 @@ var createPitchControl = function(index) {
   pitch.id = 'pitch' + index;
 
   name.value = tune[index];
-
+  name.style.borderColor = "transparent";
+  
+  
   name.onchange = function() {
     var val = name.value.toUpperCase();
     var pitchIndex = availablePitches.indexOf(val);
     if (pitchIndex != -1) {
       slider.value = pitchIndex;
-      name.value = val;
+      name.value = val; 
     } else {
       slider.value = 0;
       name.value = rest;
@@ -45,7 +50,7 @@ var createPitchControl = function(index) {
     var val = slider.value;
     name.value = availablePitches[val];
     updateTune(index, availablePitches[val]);
-	updateColor(index, tune[index]);
+	  updateColor(index, tune[index]);
     saveButton.textContent = 'Save';
   };
 
@@ -62,17 +67,24 @@ var initControls = function() {
   var staff2 = document.querySelector('.staff2');
   pitchTemplate = document.querySelector('.pitch-template');
   playButton = document.querySelector('.play-tune');
+  resetButton = document.querySelector('.reset-tune');
+  randomizeButton = document.querySelector('.randomize-tune');
   saveButton = document.querySelector('.save-tune');
 
   for (index = 0; index < tuneLength; index++) {
     newPitchControl = createPitchControl(index);
     staff = (index < tuneLength/2) ? staff1 : staff2;
     staff.appendChild(newPitchControl);
-	updateColor(index, tune[index]);
+	  updateColor(index, tune[index]);
   }
 
-  playButton.onclick = playTune;
-  saveButton.onclick = saveTune;
+  playButton.onclick  = playTune;
+  resetButton.onclick = resetTune;
+  randomizeButton.onclick = randomizeTune;
+  saveButton.onclick = function(){
+    saveTune();
+    saveOptions();
+  }
 
   editorControls.push(playButton);
 };
@@ -94,9 +106,20 @@ var enableEditor = function() {
 var flashName = function(index, duration) {
   var pitchName = pitchNames[index];
   pitchName.style.background = flashColor;
-
+  pitchName.style.borderColor = availableColors[availablePitches.indexOf(tune[index])];
+  let pitch = pitchName.value;
+  
+  if (pitch == '-'){
+    pitchName.style.transform = "scale(1.1) translate(-3px, 0) rotate(-15deg)";
+  } else 
+  if(pitch != "zZz") {
+    pitchName.style.transform = "scale(1.25) rotate(10deg)";
+  }
+  
   setTimeout(function() {
-	updateColor(index, tune[index]);
+    updateColor(index, tune[index]);
+    pitchName.style.borderColor = "transparent";
+    pitchName.style.transform = "initial";
   }, duration * 1000);
 };
 
@@ -104,6 +127,38 @@ var playTune = function() {
   disableEditor();
   tunePlayer.playTune(tune, booper, 240).eachNote(flashName).done(enableEditor);
 };
+
+var resetTune = function() {
+  tune = Array.from(defaultTune);
+  let tuneSliders = document.getElementsByClassName("pitch");
+  
+  // Setting sliders
+  for (let i = 0; i < tuneLength; i++) {
+    let range = tuneSliders[i].getElementsByClassName("pitch-slider")[0]; 
+    let label = tuneSliders[i].getElementsByClassName("pitch-name")[0];
+    label.value = tune[i];  
+    range.value = availablePitches.indexOf(tune[i]); 
+	  updateColor(i,tune[i]);
+  }
+}
+
+var randomizeTune = function(){
+  let tuneSliders = document.getElementsByClassName("pitch");
+  
+  // Randomizing sliders
+  for (let i = 0; i < tuneLength; i++) {
+    // Selecting a random pitch
+    let pitch =  availablePitches[ 2 + Math.floor( Math.random() * availablePitches.length-2 ) ];
+    tune[i] = pitch;
+    
+    // Setting values
+    let range = tuneSliders[i].getElementsByClassName("pitch-slider")[0]; 
+    let label = tuneSliders[i].getElementsByClassName("pitch-name")[0];
+    label.value = tune[i];  
+    range.value = availablePitches.indexOf(tune[i]); 
+	  updateColor(i,tune[i]);
+  }
+}
 
 var retrieveTune = function(done) {
   chrome.storage.sync.get({ townTune: defaultTune }, function(items){
@@ -130,13 +185,14 @@ var setup = function() {
 var updateColor = function(index, pitch){
   var pitchName = pitchNames[index];
   pitchName.style.background = availableColors[availablePitches.indexOf(pitch)];
-}
+} 
 
 var updateTune = function(index, pitch) {
   tune[index] = pitch;
-  booper.playNote(pitch);
+  booper.playNote(pitch, undefined, undefined, townTuneVolume);
 };
 
 window.addEventListener('load', setup);
-})();
-
+}) //();
+// changed execution of tune_editor.js by adding the jQuery document-ready method to the start (https://learn.jquery.com/using-jquery-core/document-ready/)
+// (=> This files' content waits until the page is finished loading before it runs)

--- a/scripts/options/tune_editor.js
+++ b/scripts/options/tune_editor.js
@@ -70,6 +70,7 @@ var initControls = function() {
   resetButton = document.querySelector('.reset-tune');
   randomizeButton = document.querySelector('.randomize-tune');
   saveButton = document.querySelector('.save-tune');
+  let volumeSlider = document.getElementById("townTuneVolume");
 
   for (index = 0; index < tuneLength; index++) {
     newPitchControl = createPitchControl(index);
@@ -89,6 +90,7 @@ var initControls = function() {
   editorControls.push(playButton);
   editorControls.push(resetButton);
   editorControls.push(randomizeButton);
+  editorControls.push(volumeSlider);
 };
 
 var disableEditor = function() {


### PR DESCRIPTION
Changed:
* Default town-tune to be more accurate to Wild World's default town-tune
* Increased pitch range (Automatically sized max-value for the pitch sliders, some notes weren't selectable because the max-value wasn't high enough)

Added:
* Separate volume for the town tune
* Some documentation for the root tune_player.js methods
* "Reset" & "Randomize" button for the town tune editor 
* Visual improvements to the town tune editor
* '?' pitch


