### PR TITLE
[WIP] Configure Javascript linter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+scripts/options/zepto.min.js

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,22 @@
+env:
+  browser: true
+  es6: true
+extends: 'eslint:recommended'
+globals:
+  Atomics: readonly
+  SharedArrayBuffer: readonly
+parserOptions:
+  ecmaVersion: 2018
+rules:
+  indent:
+    - error
+    - tab
+  linebreak-style:
+    - error
+    - unix
+  quotes:
+    - error
+    - single
+  semi:
+    - error
+    - always

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# =========================
+# Operating System Files
+# =========================
+
+# Windows
+# =========================
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db
@@ -17,13 +24,10 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# =========================
-# Operating System Files
-# =========================
-
 # OSX
 # =========================
 
+# OSX files
 .DS_Store
 .AppleDouble
 .LSOverride
@@ -41,9 +45,18 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
-Animal-Crossing-Music-Extension.zip
+
+# =========================
+# Extension especifc
+# =========================
+
+# NPM
+node_modules/
+
+# Ignored file extensions
 *.ogg
 *.mp3
 *.ai
+
+# Exclusions
 !sound/bells.ogg
-img/cover/kk

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ac-music-extension",
+  "version": "1.0.0",
+  "description": "Google Chrome extension that plays hourly Animal Crossing music and more while browsing!",
+  "devDependencies": {
+    "eslint": "^6.8.0"
+  }
+}

--- a/scripts/background/AudioManager.js
+++ b/scripts/background/AudioManager.js
@@ -1,4 +1,8 @@
 // Handles playing hourly music, KK, and the town tune.
+/* exported AudioManager */
+/* global TownTuneManager, MediaSessionManager, TimeKeeper */
+/* global chrome, printDebug, checkMediaSessionSupport, KKSongList, capitalize, loopTimes, formatHour */
+
 
 'use strict';
 


### PR DESCRIPTION
Related to #51. I open the PR for discussion before investing more time.

This is a POC to configure`eslint`through `npm`.
- Installed `eslint` through npm, therefore a `package.json` has been defined.
- Used the recommended `eslint` style guide, that mostly matches the current style. This enforces, among other things, **tabs** ,  **single-quotes** and **semicolons**. 

Now `npx eslint .` can be locally run from the root of the project to analyse the code.
We can run `npx eslint --fix .` before merging this to solve most formatting issues but didn't include it here not to obfuscate the tool config.

**Drawback:**

Due to the Chrome opaque way of including javascript modules, the analysis reports lots of `no-unused-vars` and `no-undef` errors. These could be disabled, but I think that they would provide very useful information for catching variables that break the build. To do so, false positives must be prevented. 

I suggest to do this by manually including `/* global ... */` and `/* exported ... */` header comments in each file to manually disable the check where needed. 

This would be a major hassle. I believe that once done, maintenance should be easy (run the tool before merging a PR). I did so for AudioManager so you could see what I mean.

I leave it to you guys to discuss!