### PR TITLE
Hotfix - Remove artificial town-tune delay by correcting town-tune timings

### DIFF
--- a/scripts/background/AudioManager.js
+++ b/scripts/background/AudioManager.js
@@ -61,8 +61,9 @@ function AudioManager(addEventListener, isTownTune) {
 		let songName = formatHour(hour);
 
 		// EVENT SONG NAME FORMATTING
-		// TODO: Re-enable events.
-		/*if(timeKeeper.getEvent() !== "none"){ //getEvent() returns eventname, or "none".
+		// TODO: Re-enable events after adding necessary files.
+		// TODO: Fetch eventsEnabled from user options instead of local boolean.
+		/*if(eventsEnabled && timeKeeper.getEvent() !== "none"){ //getEvent() returns eventname, or "none".
 			// Changing the song name to the name of the event, if an event is ongoing.
 			songName = timeKeeper.getEvent();
 		}*/

--- a/scripts/background/TownTuneManager.js
+++ b/scripts/background/TownTuneManager.js
@@ -7,14 +7,15 @@
 function TownTuneManager() {
 
 	var defaultTune = ["C2", "E2", "C2", "G1", "F1", "G1", "B1", "D2", "C2", "zZz", "G1", "zZz", "C2", "-", "-", "zZz"];
+	var defaultTownTuneVolume = 0.75;
 	var audioContext = new AudioContext();
 	var sampler = createSampler(audioContext);
 	var tunePlayer = createTunePlayer(audioContext);
 	
 	// Play tune and call doneCB after it's done
 	this.playTune = function(doneCB) {
-		chrome.storage.sync.get({ townTune: defaultTune }, function(items){
-			tunePlayer.playTune(items.townTune, sampler, 100, 2).done(doneCB);
+		chrome.storage.sync.get({ townTune: defaultTune, townTuneVolume: defaultTownTuneVolume }, function(items){
+			tunePlayer.playTune(items.townTune, sampler, 100, items.townTuneVolume).done(doneCB);
 		});
 	}
 

--- a/scripts/background/TownTuneManager.js
+++ b/scripts/background/TownTuneManager.js
@@ -14,7 +14,7 @@ function TownTuneManager() {
 	// Play tune and call doneCB after it's done
 	this.playTune = function(doneCB) {
 		chrome.storage.sync.get({ townTune: defaultTune }, function(items){
-			tunePlayer.playTune(items.townTune, sampler, 100).done(doneCB);
+			tunePlayer.playTune(items.townTune, sampler, 100, 2).done(doneCB);
 		});
 	}
 

--- a/scripts/global/tune_player.js
+++ b/scripts/global/tune_player.js
@@ -3,8 +3,7 @@
   var frequencies      = [null,  null, 350,  392,  440,  494,  523,  587,  659,  698,  784,  880,  988, 1046, 1174, 1318, "random"];
   // ^ values in HZ
   
-  var _defaultTownTuneVolume = 0.75;
-  var timeBetweenTuneEndAndMusicBeginS = 2; // In Seconds. Delays createTunePlayer.playTune()'s callback.
+  var _defaultTownTuneVolume = 0.75; //Stored in a variable as it's used in multiple places. Change if default townTuneVolume is changed.
   
   /**
    * @function createBooper
@@ -164,7 +163,7 @@ var createSampler = function(audioContext) {
 
 /**
  * @function createTunePlayer
- * @desc  Creates & returns object responsible for handling the playing of town tunes at the hour.
+ * @desc  Creates & returns object responsible for handling the playing of entire town tunes at the hour and in the editor.
  * @param {*} audioContext 
  * @param {*} bpm 
  * @returns {object} tunePlayer 
@@ -193,7 +192,7 @@ var createTunePlayer = function(audioContext, bpm) {
     return count;
   };
 
-  var playTune = function(tune, instrument, bpm) {
+  var playTune = function(tune, instrument, bpm, postTuneDelayS = 0) {
     var callbacks, i, pitch, time, sustainDuration;
     var stepDuration = getStepDuration(bpm);
     var eachNote = function(index, duration) {};
@@ -215,7 +214,7 @@ var createTunePlayer = function(audioContext, bpm) {
       sustainDuration = getSustainMultiplier(i, tune) * stepDuration;
       // Plays a note using createSampler.playNote() method
       instrument.playNote(pitch, audioContext.currentTime + time, sustainDuration); 
-      // The sustain parameter is however, not used. 
+      // The sustainDuration parameter is however not used in createSampler.playNote().
       // Look at createBooper.playNote() method for a way to implement sustain in createSampler.playNote().
     }
 
@@ -227,7 +226,7 @@ var createTunePlayer = function(audioContext, bpm) {
       },
       done: function(callback) {
         //when the tune over
-        if (callback) setTimeout(callback, stepDuration * tune.length * 1000 + timeBetweenTuneEndAndMusicBeginS * 1000);
+        if (callback) setTimeout(callback, stepDuration * tune.length * 1000 + postTuneDelayS * 1000);
         return callbacks;
       }
     };

--- a/scripts/options/tune_editor.js
+++ b/scripts/options/tune_editor.js
@@ -203,8 +203,10 @@ var updateColor = function(index, pitch){
 } 
 
 var updateTune = function(index, pitch) {
-  tune[index] = pitch;
-  booper.playNote(pitch);
+  chrome.storage.sync.get({townTuneVolume: defaultTownTuneVolume}, function(items){
+    tune[index] = pitch;
+    booper.playNote(pitch, undefined, undefined, items.townTuneVolume);
+  });
 };
 
 window.addEventListener('load', setup);

--- a/scripts/options/tune_editor.js
+++ b/scripts/options/tune_editor.js
@@ -9,11 +9,13 @@ var pitchNames = [];
 var flashColor = '#FFFFFF';
 var audioContext = new AudioContext;
 
-var booper = createBooper(audioContext);
-var sampler = createSampler(audioContext);
-var tunePlayer = createTunePlayer(audioContext);
+var booper     = createBooper(audioContext);  // Instrument for the town tune editor
+var sampler    = createSampler(audioContext); // Instrument for the town tune playing at the hour
+var tunePlayer = createTunePlayer(audioContext); // Responsible for playing town tunes
 var availablePitches = tunePlayer.availablePitches;
 var rest = availablePitches[0];
+
+var defaultTownTuneVolume = 0.75; // Fallback town tune volume, change this if the default town tune volume is altered.
 
 $(".pitch-template > .pitch-slider")[0].max = availablePitches.length-1;
 
@@ -127,9 +129,15 @@ var flashName = function(index, duration) {
   }, duration * 1000);
 };
 
+/**
+ * @method playTune
+ * @desc   Plays the town tune using createBooper as an instrument, used only by the town tune editor
+ */
 var playTune = function() {
-  disableEditor();
-  tunePlayer.playTune(tune, booper, 240).eachNote(flashName).done(enableEditor);
+  chrome.storage.sync.get({townTuneVolume: defaultTownTuneVolume}, function(items){
+    disableEditor();
+    tunePlayer.playTune(tune, booper, 240, items.townTuneVolume).eachNote(flashName).done(enableEditor);
+  });
 };
 
 var resetTune = function() {


### PR DESCRIPTION
This fix removes the need for an artificial delay after the town tune has stopped playing, thereby fixing a problem where the town tune editor controls would stay disabled until the town tune and it's added delay was over. In other words you could not continue editing in the town tune editor until two seconds after the town tune was over.

This branch fixes this by fetching the town tune volume and passing it to each of the instrument, instead of each instrument fetching the town tune volume themselves for every note. This corrects the previous timing issues, so the artificial delay has therefore been removed.