### PR TITLE
Hotfix: Sliders updating with wrong colors

### DIFF
--- a/scripts/options/tune_editor.js
+++ b/scripts/options/tune_editor.js
@@ -50,9 +50,9 @@ var createPitchControl = function(index) {
 
   slider.oninput = function() {
     var val = slider.value;
-    name.value = availablePitches[val];
-    updateTune(index, availablePitches[val]);
-	  updateColor(index, tune[index]);
+    name.value =       availablePitches[val];
+    updateTune (index, availablePitches[val]);
+	  updateColor(index, availablePitches[val]);
     saveButton.textContent = 'Save';
   };
 


### PR DESCRIPTION
The method that changed the colors of the sliders when they were updated, passed a pitch parameter that depended on another method completing execution before the parameter was passed, resulting in the colors of the previous pitch being applied to the new pitch, making colors inconsistent. Fixed by changing the parameter to a consistent method of getting pitch.