### PR TITLE
Fix: Pausing causes events to be missed

### DIFF
--- a/scripts/background/AudioManager.js
+++ b/scripts/background/AudioManager.js
@@ -225,7 +225,6 @@ function AudioManager(addEventListener, isTownTune) {
 		if (newVolume > 1) newVolume = 1;
 
 		audio.volume = newVolume;
-		console.log(audio.volume)
 	}
 
 	addEventListener("hourMusic", playHourlyMusic);
@@ -257,7 +256,7 @@ function AudioManager(addEventListener, isTownTune) {
 					audio.pause();
 					tabAudioPaused = true;
 				} else {
-					if (audio.paused && audio.readyState >= 3) {
+					if (audio.paused && (audio.readyState >= 3 || audio.readyState == 0)) {
 						if (!townTunePlaying) audio.play();
 						tabAudioPaused = false;
 						// Get the badge icon updated.

--- a/scripts/background/AudioManager.js
+++ b/scripts/background/AudioManager.js
@@ -29,6 +29,7 @@ function AudioManager(addEventListener, isTownTune) {
 	let reduceVolumeValue = 0;
 	let reducedVolume = false;
 	let tabAudioPaused = false;
+	let pausedDuringTownTune = false;
 
 	// isHourChange is true if it's an actual hour change,
 	// false if we're activating music in the middle of an hour
@@ -42,7 +43,8 @@ function AudioManager(addEventListener, isTownTune) {
 				townTunePlaying = true;
 				townTuneManager.playTune(false, () => {
 					townTunePlaying = false;
-					playHourSong(game, weather, hour, false);
+					if (!pausedDuringTownTune) playHourSong(game, weather, hour, false);
+					else pausedDuringTownTune = false;
 				});
 			} else playHourSong(game, weather, hour, false);
 		});
@@ -238,6 +240,7 @@ function AudioManager(addEventListener, isTownTune) {
 	addEventListener("pause", () => {
 		clearLoop();
 		fadeOutAudio(300);
+		if (townTunePlaying) pausedDuringTownTune = true;
 	});
 
 	addEventListener("volume", newVol => {

--- a/scripts/background/AudioManager.js
+++ b/scripts/background/AudioManager.js
@@ -86,6 +86,8 @@ function AudioManager(addEventListener, isTownTune) {
 
 		audio.onpause = onPause;
 
+		setVolume();
+
 		audio.onplay = () => {
 			// If we resume mid-song, then we recalculate the delayToLoop
 			if (started && loopTime) {
@@ -223,6 +225,7 @@ function AudioManager(addEventListener, isTownTune) {
 		if (newVolume > 1) newVolume = 1;
 
 		audio.volume = newVolume;
+		console.log(audio.volume)
 	}
 
 	addEventListener("hourMusic", playHourlyMusic);

--- a/scripts/background/StateManager.js
+++ b/scripts/background/StateManager.js
@@ -64,7 +64,7 @@ function StateManager() {
 	// Possible events include:
 	// volume, kkStart, hourMusic, gameChange, weatherChange, pause, tabAudio, musicFailed
 	function notifyListeners(event, args) {
-		if (!options.paused || event === "pause") {
+		if (!options.paused || event === "pause" || event === "volume") {
 			var callbackArr = callbacks[event] || [];
 			for (var i = 0; i < callbackArr.length; i++) {
 				callbackArr[i].apply(window, args);

--- a/scripts/background/StateManager.js
+++ b/scripts/background/StateManager.js
@@ -58,6 +58,7 @@ function StateManager() {
 			}
 
 			if (!tabAudio.activated) tabAudio.activate();
+			else tabAudio.checkTabs(true);
 		});
 	};
 


### PR DESCRIPTION
While the extension is paused, some events are missed and cause incorrect behaviour because of this. The following events were fixed in this PR:
- **Music volume adjustments:** updating the volume in options while the music is paused did not reflect it upon resuming, as the volume change event would be missed, closes #84
- **Tab audio stopping:** if a tab is playing audio before the music is manually paused, then the tab stops playing audio before the music is then resumed, the music would be stuck in a paused state as the stopping event would be missed
- **Music pausing during town tune:** if the user manually pauses the extension while music is playing, the extension would get stuck in an invalid state, thinking it was paused while playing the music, as the pause event would be missed, closes #91