### PR TITLE
Fix - Correct pitch range & colors & Town Tune default.

### DIFF
--- a/scripts/background/TownTuneManager.js
+++ b/scripts/background/TownTuneManager.js
@@ -6,7 +6,8 @@
 
 function TownTuneManager() {
 
-	var defaultTune = ["C2", "E2", "C2", "G1", "F1", "G1", "B1", "D2", "C2", "zZz", "G1", "zZz", "C2", "-", "-", "zZz"];
+	// var defaultTune = ["C2", "E2", "C2", "G1", "F1", "G1", "B1", "D2", "C2", "zZz", "G1", "zZz", "C2", "-", "-", "zZz"];
+	var defaultTune = ["C3", "E3", "C3", "G2", "F2", "G2", "B2", "D3", "C3", "zZz", "?", "zZz", "C3", "-", "-", "zZz"];
 	var defaultTownTuneVolume = 0.75;
 	var defaultTabAudio = 'pause';
 	var defaultTabAudioReduceVolume = 80;

--- a/scripts/global/tune_player.js
+++ b/scripts/global/tune_player.js
@@ -1,12 +1,14 @@
 (function() {
-  var availablePitches = ['zZz', '-', 'F1', 'G1', 'A1', 'B1', 'C2', 'D2', 'E2', 'F2', 'G2', 'A2', 'B2', 'C3', 'D3', 'E3', '?'];
-  var frequencies      = [null,  null, 350,  392,  440,  494,  523,  587,  659,  698,  784,  880,  988, 1046, 1174, 1318, "random"];
+     var availablePitches = ['zZz', '-', 'G1', 'A1', 'B1', 'C2', 'D2', 'E2', 'F2', 'G2', 'A2', 'B2', 'C3', 'D3', 'E3', '?'];
+  // var availablePitches = ['zZz', '-', 'F1', 'G1', 'A1', 'B1', 'C2', 'D2', 'E2', 'F2', 'G2', 'A2', 'B2', 'C3', 'D3', 'E3', '?'];
+  // var frequencies      = [null,  null, 350,  392,  440,  494,  523,  587,  659,  698,  784,  880,  988, 1046, 1174, 1318, "random"];
+     var frequencies      = [null,  null, 392,  440,  494,  523,  587,  659,  698,  784,  880,  988, 1046, 1174, 1318, "random"];
   // ^ values in HZ
   
   
   /**
    * @function createBooper
-   * @desc  Creates & returns instrument responsible for playing town-tune notes in the town-tune editor
+   * @desc  Creates & returns instrument (playNote method) used to play each note in the town tune, when it's played or updated in the town-tune editor
    * @param {*} audioContext 
    * @returns {method} playNote
    */
@@ -81,14 +83,14 @@
   
 /**
  * @function createSampler
- * @desc  Creates & returns instrument responsible for playing notes used to play the town tune at the hour
+ * @desc  Creates & returns instrument (playNote method) used to play each note in the town tune, when it's played at the hour
  * @param {*} audioContext 
  * @returns {method} playNote
  */
 var createSampler = function(audioContext) {
   var bellBuffer;
   var startPoints = [null, null];
-  var chimeLength = 3.8;
+  var chimeLength = 3.8; 
 
   var pitchToStartPoint = function(pitch) {
     index = availablePitches.indexOf(pitch);

--- a/scripts/options/tune_editor.js
+++ b/scripts/options/tune_editor.js
@@ -1,9 +1,9 @@
 $(function(){
 var pitchTemplate, playButton, saveButton, tune;
-const defaultTune = ["C2", "E2", "C2", "G1", "F1", "G1", "B1", "D2", "C2", "zZz", "G1", "zZz", "C2", "-", "-", "zZz"]; // From AC : Wild World. Old default: ["G2", "E3", "-", "G2", "F2", "D3", "-", "B2", "C3", "zZz", "C2", "zZz", "C2", "-", "-", "zZz"];
+const defaultTune = ["C3", "E3", "C3", "G2", "F2", "G2", "B2", "D3", "C3", "zZz", "?", "zZz", "C3", "-", "-", "zZz"]; // From AC: Wild World
 var tuneLength = 16;
-var availableColors = ["#a4a2d0", "#e4b3d3", "#5eccf5", "#12fee0", "#53fd8a", "#79fc4e", "#a8fd35", "#d0fe47", "#e4fd39", 
-                       "#f9fe2e", "#fefa43", "#fef03f", "#fcd03a", "#fcb141", "#fe912e", "#FE672E", "#FA5C90", "#ba32a4"];
+var availableColors = ["#A4A4FF", "#FFB0FF", "#52D3FE", "#12FEE0", "#53FD8A", "#79FC4E", "#A8FD35", "#D0FE47",
+                       "#E4FD39", "#F9FE2E", "#FEFA43", "#FEF03F", "#FCD03A", "#FCB141", "#FE912E", "#FE7929"];
 var editorControls = [];
 var pitchNames = [];
 var flashColor = '#FFFFFF';
@@ -15,7 +15,7 @@ var tunePlayer = createTunePlayer(audioContext); // Responsible for playing town
 var availablePitches = tunePlayer.availablePitches;
 var rest = availablePitches[0];
 
-var defaultTownTuneVolume = 0.75; // Fallback town tune volume, change this if the default town tune volume is altered.
+var defaultTownTuneVolume = 0.75; // Default town tune volume, used as fallback when retreiving town tune volume from chrome storage. (Just here to make it easier to change)
 
 $(".pitch-template > .pitch-slider")[0].max = availablePitches.length-1;
 


### PR DESCRIPTION
This branch fixes the issue of the E3 note not playing, by removing the F1 pitch, which doesn't exist in the AC games.

With the E3 pitch now working, the default Town Tune has also been changed to the correct pitches, making its pitches the exact same as the in-game (Wild World) default.

The colors of the town-tune editor's pitches have also been updated, using a color picker & town-tune-editor assets from Wild World, making the town tune editor feel visually much more like it's in-game Wild World counterpart, also making the colors much more lively. 