### PR TITLE
Fix: background option not requesting permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -39,6 +39,9 @@
       "storage",
       "https://acmusicext.com/"
    ],
+   "optional_permissions": [
+      "background"
+   ],
    "update_url": "https://clients2.google.com/service/update2/crx",
-   "version": "4.1.1"
+   "version": "4.2.0"
 }

--- a/options.html
+++ b/options.html
@@ -264,6 +264,10 @@
 				</header>
 
 				<div class="content">
+					<h3>Version 4.2.0<span class="changelog-date"> - ???</span></h3>
+					<ul class="changelog-list">
+						<li>Fixed a bug causing the extension to sometimes not run in the background when the feature was enabled.</li>
+					</ul>
 					<h3>Version 4.1.1<span class="changelog-date"> - 14th of March 2020</span></h3>
 					<ul class="changelog-list">
 						<li>Removed the F1 note as it was not meant to exist</li>

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -17,7 +17,6 @@ const onClickElements = [
 	'absolute-town-tune',
 	'enable-notifications',
 	'enable-badge',
-	'enable-background',
 	'kk-version-live',
 	'kk-version-aircheck',
 	'kk-version-both',
@@ -72,6 +71,23 @@ window.onload = function () {
 			element.onanimationend = () => element.style.animation = null;
 		}
 	});
+
+	let enableBackgroundEl = document.getElementById('enable-background');
+	enableBackgroundEl.onclick = () => {
+		chrome.permissions.contains({ permissions: ['background'] }, hasPerms => {
+			if (enableBackgroundEl.checked) {
+				chrome.permissions.contains({ permissions: ['background'] }, hasPerms => {
+					if (hasPerms) saveOptions();
+					else {
+						chrome.permissions.request({ permissions: ['background'] }, hasPerms => {
+							if (hasPerms) saveOptions();
+							else enableBackgroundEl.checked = false;
+						});
+					}
+				});
+			} else if (hasPerms) chrome.permissions.remove({ permissions: ['background'] });
+		});
+	}
 
 	updateContributors();
 }


### PR DESCRIPTION
Requests permission from the browser to allow itself to run in the background, even when the browser is closed. Closes #110