### PR TITLE
Tune town should only play when enabled

### DIFF
--- a/scripts/background/StateManager.js
+++ b/scripts/background/StateManager.js
@@ -160,7 +160,8 @@ function StateManager() {
 		else if (!isKK()) {
 			let musicAndWeather = getMusicAndWeather();
 			notifyListeners("hourMusic", [hour, musicAndWeather.weather, musicAndWeather.music, true]);
-			if (options.paused && options.absoluteTownTune) townTuneManager.playTune(tabAudio.audible);
+			// Play hourly tune when paused, but only if town tune is enabled
+			if (options.paused && (options.absoluteTownTune && options.enableTownTune)) townTuneManager.playTune(tabAudio.audible);
 		}
 	});
 


### PR DESCRIPTION
Fixes #131 

Logic in the `StateManager.js` only checked the `absoluteTownTune` setting, so the hourly tune/town tune would continue to play even when `enableTownTune` is false. 

Decided to keep this change small and check the `enableTownTune` setting as well. Optionally, `absoluteTownTune` could be set to false/unchecked as well, but decided against altering user settings. 