### PR TITLE
ci: add extension auto-publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish Extension
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, e.g v6.0.5"
+        required: true
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Github Release Assets
+        uses: PlasmoHQ/download-release-asset@v1
+        with:
+          tag: ${{ github.event.inputs.tag }}
+      - name: Browser Platform Publisher
+        uses: PlasmoHQ/bpp@v2
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}
+          artifact: ${{ github.event.inputs.tag }}.zip

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ img/cover/kk
 
 # IDEA
 .idea
+
+keys.json


### PR DESCRIPTION
**Happy Hacktoberfest!**

I've created a GitHub workflow for your repository that uses https://github.com/PlasmoHQ/bpp to automatically publish your extension to the Chrome Web Store whenever you initiate a dispatch from the [actions](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) tab. After you've published a tagged GitHub release, you can input that tag into this workflow, and it will fetch the release asset and send it straight to the CWS.

All that you as a maintainer will need to do is create a new GitHub secret called `SUBMIT_KEYS`, which will be a JSON object with your chrome web store API keys. The JSON schema is defined [here](https://github.com/PlasmoHQ/bpp/blob/main/keys.schema.json).

There are instructions on how to get the CWS keys in the JSON schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the JSON properties. Generating a CWS clientId/refreshToken should take no more than 10-15min. If you need any help in setting up the keys, feel free to ping me! Otherwise if this doesn't seem necessary, feel free to close the PR. Cheers!